### PR TITLE
ci: remove deprecated macos-12 runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,7 +213,6 @@ jobs:
         os:
           #- macos-14  # no virt: https://github.com/docker/actions-toolkit/issues/317
           - macos-13
-          - macos-12
     steps:
       -
         name: Checkout


### PR DESCRIPTION
https://github.com/actions/runner-images/issues/10721