### PR TITLE
ci: update to macos-15-intel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,7 @@ jobs:
         os:
           - ubuntu-latest
           - ubuntu-24.04-arm
-          #- macos-14  # no virt: https://github.com/docker/actions-toolkit/issues/317
-          - macos-13
+          - macos-15-intel
           - windows-latest
         version:
           - ""
@@ -54,8 +53,7 @@ jobs:
         os:
           - ubuntu-latest
           - ubuntu-24.04-arm
-          #- macos-14  # no virt: https://github.com/docker/actions-toolkit/issues/317
-          - macos-13
+          - macos-15-intel
           - windows-latest
     steps:
       -
@@ -76,8 +74,7 @@ jobs:
         os:
           - ubuntu-latest
           - ubuntu-24.04-arm
-          #- macos-14  # no virt: https://github.com/docker/actions-toolkit/issues/317
-          - macos-13
+          - macos-15-intel
           - windows-latest
     steps:
       -
@@ -104,8 +101,7 @@ jobs:
         os:
           - ubuntu-latest
           - ubuntu-24.04-arm
-          #- macos-14  # no virt: https://github.com/docker/actions-toolkit/issues/317
-          - macos-13
+          - macos-15-intel
           - windows-latest
     steps:
       -
@@ -123,8 +119,7 @@ jobs:
           docker context inspect foo
 
   lima-start-args:
-    #runs-on: macos-14  # no virt: https://github.com/docker/actions-toolkit/issues/317
-    runs-on: macos-13
+    runs-on: macos-15-intel
     steps:
       -
         name: Checkout
@@ -188,8 +183,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          #- macos-14  # no virt: https://github.com/docker/actions-toolkit/issues/317
-          - macos-13
+          - macos-15-intel
     steps:
       -
         name: Checkout
@@ -285,8 +279,7 @@ jobs:
         os:
           - ubuntu-latest
           - ubuntu-24.04-arm
-          #- macos-14  # no virt: https://github.com/docker/actions-toolkit/issues/317
-          - macos-13
+          - macos-15-intel
           - windows-latest
     steps:
       -
@@ -337,7 +330,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-13
+          - macos-15-intel
           - windows-latest
     steps:
       -


### PR DESCRIPTION
follow-up https://github.com/docker/actions-toolkit/pull/822