### PR TITLE
Add github-token input to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,16 +113,17 @@ jobs:
 
 The following inputs can be used as `step.with` keys
 
-| Name              | Type   | Default                      | Description                                                                                                                 |
-|-------------------|--------|------------------------------|-----------------------------------------------------------------------------------------------------------------------------|
-| `version`         | String | `latest`                     | Docker version to use. See [inputs.version](#inputs.version).                                                               |
-| `channel`         | String | `stable`                     | Docker CE [channel](https://download.docker.com/linux/static/) (`stable` or `test`). Only applicable to `type=archive`      |
-| `daemon-config`   | String |                              | [Docker daemon JSON configuration](https://docs.docker.com/engine/reference/commandline/dockerd/#daemon-configuration-file) |
-| `tcp-port`        | Number |                              | TCP port to expose the Docker API locally                                                                                   |
-| `context`         | String | `setup-docker-action`        | Docker context name.                                                                                                        |
-| `set-host`        | Bool   | `false`                      | Set `DOCKER_HOST` environment variable to docker socket path.                                                               |
-| `rootless`        | Bool   | `false`                      | Start daemon in rootless mode                                                                                               |
-| `runtime-basedir` | String | `<home>/setup-docker-action` | Docker runtime base directory                                                                                               |
+| Name              | Type   | Default                      | Description                                                                                                                                                  |
+|-------------------|--------|------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `version`         | String | `latest`                     | Docker version to use. See [inputs.version](#inputs.version).                                                                                                |
+| `channel`         | String | `stable`                     | Docker CE [channel](https://download.docker.com/linux/static/) (`stable` or `test`). Only applicable to `type=archive`                                       |
+| `daemon-config`   | String |                              | [Docker daemon JSON configuration](https://docs.docker.com/engine/reference/commandline/dockerd/#daemon-configuration-file)                                  |
+| `tcp-port`        | Number |                              | TCP port to expose the Docker API locally                                                                                                                    |
+| `context`         | String | `setup-docker-action`        | Docker context name.                                                                                                                                         |
+| `set-host`        | Bool   | `false`                      | Set `DOCKER_HOST` environment variable to docker socket path.                                                                                                |
+| `rootless`        | Bool   | `false`                      | Start daemon in rootless mode                                                                                                                                |
+| `runtime-basedir` | String | `<home>/setup-docker-action` | Docker runtime base directory                                                                                                                                |
+| `github-token`    | String | `${{ github.token }}`        | Optional GitHub Token used to get releases and download assets to avoid rate limitation. On GitHub Enterprise, you might need to set a PAT for `github.com`. |
 
 ### inputs.version
 


### PR DESCRIPTION
Version [v4.5.0](https://github.com/docker/setup-docker-action/releases/tag/v4.5.0) introduced [usage of the GitHub token for downloads](https://github.com/docker/setup-docker-action/pull/182). 

Unfortunately this change was not backwards compatible on GitHub Enterprise instances (`<company>.ghe.com`) as the downloads require a token for `github.com`, and not the token from the dedicated GHE server/cloud which is present in `github.token`. Maybe a new major `v5` would have been nice.

This PR just adds the `github-token` input to the readme to make it easier for GHE users to discover this input and to pass in a github.com token e.g. from a secret. 